### PR TITLE
Created CleanupTask for cleaning up md directories.

### DIFF
--- a/mdworks/firetasks.py
+++ b/mdworks/firetasks.py
@@ -8,8 +8,8 @@ from fireworks import FireTaskBase, FWAction
 
 class BeaconTask(FireTaskBase):
     """
-    A FireTask to tell the next Firework where the generated files are
-    so they can be pulled back down.
+    A FireTask to tell the child Firework(s) where the generated files are so
+    they can be pulled back down.
 
     """
     _fw_name = 'BeaconTask'
@@ -68,6 +68,57 @@ class FilePullTask(FireTaskBase):
                     raise ValueError(
                         "There was an error performing operation {} from {} "
                         "to {}".format(mode, self["files"], self["dest"]))
+
+        sftp.close()
+        ssh.close()
+
+
+class CleanupTask(FireTaskBase)
+    """
+    A FireTask for removing the directory and all files generated from an MD
+    run.
+
+    """
+    _fw_name = 'CleanupTask'
+
+    def run_task(self, fw_spec):
+        shell_interpret = self.get('shell_interpret', True)
+        ignore_errors = self.get('ignore_errors')
+
+        # remote transfers
+        # Create SFTP connection
+        import paramiko
+        ssh = paramiko.SSHClient()
+        ssh.load_host_keys(expanduser(os.path.join("~", ".ssh", "known_hosts")))
+        ssh.connect(fw_spec['server'], username=fw_spec['user'], key_filename=self.get('key_filename'))
+        sftp = ssh.open_sftp()
+
+        def delete_dir(sftp, directory):
+            for g in sftp.listdir(directory):
+                # first try to remove as a file
+                try:
+                    sftp.remove(os.path.join(directory, g))
+                except OSError:
+                    # must be a directory; first go inside and delete all files
+                    delete_dir(os.path.join(directory, g))
+
+                    # then delete the directory
+                    sftp.rmdir(directory)
+
+        for item in fw_spec["files"]:
+            try:
+                # try case where item is a directory
+                try:
+                    delete_dir(sftp, item)
+                except IOError:
+                    # if src isn't a directory, it should be a file
+                    sftp.remove(item)
+            except:
+                traceback.print_exc()
+                if not ignore_errors:
+                    raise ValueError(
+                        "There was an error deleting {} from {}".format(
+                            item,fw_spec['server']))
 
         sftp.close()
         ssh.close()

--- a/mdworks/firetasks.py
+++ b/mdworks/firetasks.py
@@ -241,8 +241,8 @@ class CleanupTask(FireTaskBase):
                 # first remove files
                 sftp.remove(os.path.join(directory, g))
 
-                # then delete the directory
-                sftp.rmdir(directory)
+            # then delete the directory
+            sftp.rmdir(directory)
 
         for item in fw_spec["files"]:
             try:
@@ -254,10 +254,7 @@ class CleanupTask(FireTaskBase):
                     sftp.remove(item)
             except:
                 traceback.print_exc()
-                if not ignore_errors:
-                    raise ValueError(
-                        "There was an error deleting {} from {}".format(
-                            item,fw_spec['server']))
+                raise
 
         sftp.close()
         ssh.close()

--- a/mdworks/firetasks.py
+++ b/mdworks/firetasks.py
@@ -216,7 +216,7 @@ class FilePullTask(FireTaskBase):
         ssh.close()
 
 
-class CleanupTask(FireTaskBase)
+class CleanupTask(FireTaskBase):
     """
     A FireTask for removing the directory and all files generated from an MD
     run.

--- a/mdworks/firetasks.py
+++ b/mdworks/firetasks.py
@@ -223,12 +223,12 @@ class CleanupTask(FireTaskBase)
 
     """
     _fw_name = 'CleanupTask'
+    required_params = ["uuid"]
 
     def run_task(self, fw_spec):
         shell_interpret = self.get('shell_interpret', True)
         ignore_errors = self.get('ignore_errors')
 
-        # remote transfers
         # Create SFTP connection
         import paramiko
         ssh = paramiko.SSHClient()
@@ -238,15 +238,11 @@ class CleanupTask(FireTaskBase)
 
         def delete_dir(sftp, directory):
             for g in sftp.listdir(directory):
-                # first try to remove as a file
-                try:
-                    sftp.remove(os.path.join(directory, g))
-                except OSError:
-                    # must be a directory; first go inside and delete all files
-                    delete_dir(os.path.join(directory, g))
+                # first remove files
+                sftp.remove(os.path.join(directory, g))
 
-                    # then delete the directory
-                    sftp.rmdir(directory)
+                # then delete the directory
+                sftp.rmdir(directory)
 
         for item in fw_spec["files"]:
             try:


### PR DESCRIPTION
Addresses #5.

This could be VERY dangerous if it isn't working as expected, so I have
not yet added this to any workflows generated by this library. For
workflows it is added to, it should probably be an opt-in kwarg to
include it.

It will delete 'files' in the fw_spec, which in this context
would be defined by BeaconTask. BeaconTask currently only puts the
'SCRATCHDIR' environment variable in this list of files, so that should
be the only thing deleted. It WOULD be catastrophic if somebody made
SCRATCHDIR a directory they didn't want to be deleted in full after a
run (like their home directory...).
